### PR TITLE
minor attribute name fix

### DIFF
--- a/libs/player/src/lib/providers/player.provider.ts
+++ b/libs/player/src/lib/providers/player.provider.ts
@@ -192,8 +192,8 @@ export class PlayerProvider extends MetaProvider {
     });
 
     sceneEl.querySelectorAll('[networked-audio-source]').forEach((el) => {
-      el.removeAttribute('networked-ausio-source');
-      el.setAttribute('networked-ausio-source', '');
+      el.removeAttribute('networked-audio-source');
+      el.setAttribute('networked-audio-source', '');
     });
   }
 }


### PR DESCRIPTION
The Player provider has a minor typo error due to which the networked-audio-source is not set properly.
The PR is to fix that.