### PR TITLE
redirect for serve in demo app

### DIFF
--- a/apps/demo/project.json
+++ b/apps/demo/project.json
@@ -31,6 +31,11 @@
             "input": ".",
             "output": "."
           },
+          {
+            "glob": "apps/demo/src/serve.json",
+            "input": ".",
+            "output": "."
+          },
           "apps/demo/src/assets"
         ]
       },

--- a/apps/demo/src/serve.json
+++ b/apps/demo/src/serve.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/**", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Currently deep links like http://localhost:3000/home/ or http://localhost:3000/experiences/cinemavr/ do work as the `serve` is missing the redirects . This PR fixes it.